### PR TITLE
Cache headers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -118,9 +118,9 @@ module.exports = function(grunt) {
           // And also a bleeding edge minor release.
           {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.<%= pkg.version.split(".")[1] %>.latest/', params: { CacheControl: 'public, max-age=86400' }},          
           // Also deploy a bleeding edge version on the major number.
-          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.latest/'},
+          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.latest/', params: { CacheControl: 'public, max-age=3600' }},
           // A non-version latest release.
-          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/latest/'}
+          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/latest/', params: { CacheControl: 'public, max-age=3600' }}
         ]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,10 +115,10 @@ module.exports = function(grunt) {
         files: [
           // Upload this version of the plugin.
           {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version %>/', params: { CacheControl: 'public, max-age=31536000' }},
+          // And also a bleeding edge minor release.
+          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.<%= pkg.version.split(".")[1] %>.latest/', params: { CacheControl: 'public, max-age=86400' }},          
           // Also deploy a bleeding edge version on the major number.
           {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.latest/'},
-          // And also a bleeding edge minor release.
-          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.<%= pkg.version.split(".")[1] %>.latest/'},
           // A non-version latest release.
           {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/latest/'}
         ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function(grunt) {
       dev: {
         files: [
           // Upload this version of the plugin.
-          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version %>/'},
+          {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version %>/', params: { CacheControl: 'public, max-age=31536000' }},
           // Also deploy a bleeding edge version on the major number.
           {expand: true, cwd: 'dist/', src: ['**'], dest: '<%= pkg.name %>/<%= pkg.version.split(".")[0] %>.latest/'},
           // And also a bleeding edge minor release.


### PR DESCRIPTION
I added some conservative cache headers to the files to help improve performance. Fine-grained version numbers such as `x.x.x` are running a maximum cache of a year, whereas dynamic builds like `x.latest` run a short 1-hour cache so we can reliably roll out patches without too much delay.